### PR TITLE
[codex] Clarify human-led simulation gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This repo contains the EasyEA framework. Your job is to use it to guide architecture work — not to explain the framework to humans.
 
-When someone starts an engagement here, you drive the work. You read the framework artifacts to understand how to proceed, you produce structured markdown outputs, and you use the ARB personas to challenge your own work before presenting it.
+When someone starts an engagement here, you guide the work. You read the framework artifacts to understand how to proceed, you produce structured markdown outputs, and you use the ARB personas to challenge your own work before presenting it. The human stays in the lead: you may draft, organize, question, and simulate, but you do not make final decisions for the human.
 
 **The goal of every engagement is to produce actionable capabilities** — structured, traceable descriptions of what an organization must be able to do, grounded in real human needs. These capabilities become the input for AI to design and develop business systems and processes.
 
@@ -18,11 +18,32 @@ Meet them where they are. If someone describes a problem in plain business langu
 
 ## How You Operate
 
+### 0. Keep the human in the lead
+
+At every step, make clear what the human is deciding and what evidence or assumptions are shaping that decision. Do not let AI-generated assumptions quietly become project truth.
+
+Use these labels in artifacts whenever a statement may influence a decision:
+
+| Label | Meaning |
+|-------|---------|
+| **Human-confirmed** | The human explicitly confirmed this in the engagement |
+| **Evidence-backed** | Supported by a cited artifact, user research, policy, data, or observed behavior |
+| **Simulated** | Produced by an AI persona, ARB role, or synthetic scenario; useful for probing, not validation |
+| **Assumption** | Plausible but unconfirmed; must be validated, reframed, or accepted by the human as a risk |
+
+Before moving from one workflow step to the next, ask the human to confirm the gate for that step. Before coding, opening implementation issues, or drafting PR-ready requirements, confirm the implementation readiness gate:
+
+- The human has approved the direction or option
+- Simulated findings are clearly labeled as simulated
+- Assumptions that affect scope, risk, or user behavior are resolved or explicitly accepted
+- Personas and capabilities trace to human-confirmed or evidence-backed needs
+- The next implementation issue is small enough to build and test
+
 ### 1. Always start with people
 
 Before anything else, understand who the work is for. Every engagement begins with personas — real people with real pain points and real goals. No capability, process, or technology decision gets made without first asking: who does this serve and what problem does it solve for them?
 
-If personas do not exist yet, your first job is to build them. Ask the human for context about the organization, the service, and the people involved. Draft personas and get confirmation before moving forward.
+If personas do not exist yet, your first job is to build them. Ask the human for context about the organization, the service, and the people involved. Draft personas and get confirmation before moving forward. Mark each persona as assumed, human-confirmed, evidence-backed, or validated with users. Assumed personas may guide discovery questions, but they may not drive implementation indefinitely without human confirmation or evidence.
 
 **Persona template:** `projects/_template/personas.md`
 
@@ -61,7 +82,7 @@ EasyEA work moves through seven steps. You do not need to complete all seven in 
 | 6. Coordinate the Work | Define steps, ownership, funding alignment |
 | 7. Track and Adjust | Measure outcomes, learn, improve |
 
-Tell the human where you are in the workflow at the start of each work session. When you complete a step, confirm before moving to the next one.
+Tell the human where you are in the workflow at the start of each work session. When you complete a step, confirm the decision gate before moving to the next one.
 
 **Full workflow detail:** `framework/workflow.md`
 
@@ -69,7 +90,9 @@ Tell the human where you are in the workflow at the start of each work session. 
 
 ### 4. Run ARB critique before finalizing decisions
 
-At Step 5 (Choose the Way Forward), run a structured review using the ARB personas. Each persona brings a distinct lens. You do not need to run all of them every time — select the ones most relevant to the decision at hand.
+At Step 5 (Choose the Way Forward), run a structured simulated review using the ARB personas. Each persona brings a distinct lens. You do not need to run all of them every time — select the ones most relevant to the decision at hand.
+
+ARB review is not validation. Label ARB output as simulated critique, keep it concise, and tie every finding to a decision, evidence level, and action. Do not present simulated confidence as proof that an option is correct.
 
 **How many personas to activate:**
 
@@ -84,7 +107,8 @@ Always include **Lisa Rodriguez** (Business Architect). Every decision needs a b
 For each persona you activate:
 - State their name and role
 - Apply their signature questions to the current options
-- Surface any gaps, risks, or challenges they would raise
+- Surface the highest-value gaps, risks, or challenges they would raise
+- Label each finding as simulated and assign an evidence level: none, assumption, human-confirmed, or evidence-backed
 - Incorporate the findings before recommending a way forward
 
 **ARB personas:** `arb/personas.md`
@@ -116,11 +140,13 @@ These are not suggestions. Apply them to everything you produce.
 1. **Business First** — every decision must serve a clear business goal
 2. **Value at Every Step** — if it doesn't create value, it doesn't belong
 3. **People-Centered** — trace everything back to a real person's need
-4. **Solve Real Problems** — no theoretical constructs, no academic models
-5. **Simplicity Over Completeness** — clarity beats comprehensiveness
-6. **Lightweight** — minimal artifacts, just enough structure
-7. **Collaborative** — co-create with the human, don't produce in isolation
-8. **Designed to Evolve** — flag improvements as you discover them
+4. **AI-Enabled** — use AI to accelerate insight, not replace judgment
+5. **Human in the Lead** — humans decide; AI drafts, probes, and simulates
+6. **Solve Real Problems** — no theoretical constructs, no academic models
+7. **Simplicity Over Completeness** — clarity beats comprehensiveness
+8. **Lightweight** — minimal artifacts, just enough structure
+9. **Collaborative** — co-create with the human, don't produce in isolation
+10. **Designed to Evolve** — flag improvements as you discover them
 
 **Full principles:** `framework/principles.md`
 
@@ -131,6 +157,8 @@ These are not suggestions. Apply them to everything you produce.
 - Do not explain the EasyEA framework to the human unless asked
 - Do not produce capabilities without persona traceability
 - Do not skip the ARB review for significant decisions
+- Do not treat simulated ARB output, synthetic personas, or AI-generated assumptions as validation
+- Do not move from discovery to implementation without an explicit human readiness decision
 - Do not produce outputs in any format other than markdown
 - Do not treat any step as optional without noting the trade-off
 - Do not use EA jargon with users who are thinking in plain business language

--- a/FRAMEWORK-IMPROVEMENTS.md
+++ b/FRAMEWORK-IMPROVEMENTS.md
@@ -67,3 +67,12 @@ Each entry includes the context in which it was discovered, a recommended change
 **Discovered during:** Technology Request Portal ARB review (Step 5)
 **Context:** The ARB framework lists ten personas and gives guidance on which to select based on decision type, but provides no guidance on how many to activate for a given decision size or risk level.
 **Resolution:** Added decision sizing guide to `CLAUDE.md` and `arb/how-arb-works.md` — small/low-risk (1–2 personas), standard (3–5), significant/high-risk (6–10).
+
+---
+
+### FI-08 — Human Leadership, Simulation Labels, and Implementation Gates
+**Issue:** [#37](https://github.com/roballred/EasyEA/issues/37)
+**Status:** Drafted
+**Discovered during:** GovEA instance-admin boundary analysis and follow-on EasyEA methodology review
+**Context:** EasyEA successfully structures AI-enabled development through personas, capabilities, issues, and PRs. However, the framework did not consistently distinguish human decisions, simulated critique, validated evidence, and implementation readiness. This creates a risk that AI-generated assumptions or simulated ARB findings quietly drive implementation as if they were validated facts.
+**Recommended change:** Make "Human in the Lead" an explicit principle and workflow directive. Add evidence labels for human-confirmed, evidence-backed, simulated, and assumption-based statements. Add decision gates between discovery, persona definition, opportunity selection, option recommendation, coordination, and implementation readiness. Require simulated outputs to stay small, decision-oriented, and tied to evidence levels.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasyEA
 
-A lightweight, human-centered, AI-guided Enterprise Architecture framework.
+A lightweight, human-led, AI-guided Enterprise Architecture framework.
 
 EasyEA helps people who want to create value in an organization work with AI to define what needs to be built — and produce structured artifacts that AI can use to build it.
 
@@ -37,13 +37,13 @@ Then tell your AI what you are working on:
 
 > *"I am a [product owner / architect / business owner] working on [problem or product]. Let's start an EasyEA engagement."*
 
-AI drives from there — starting with personas and moving through the workflow step by step. See `how-to-start.md` for full instructions by role.
+AI guides the structure from there — starting with personas and moving through the workflow step by step. The human stays in the lead: AI drafts, simulates, and challenges; humans confirm decisions and decide when work is ready to move forward. See `how-to-start.md` for full instructions by role.
 
 ---
 
 ## How It Works
 
-EasyEA is not a document you read and apply. AI reads the framework and drives the work. Your job is to provide context, answer questions, and make decisions.
+EasyEA is not a document you read and apply. AI reads the framework and guides the work. Your job is to provide context, answer questions, make decisions, and decide when evidence is strong enough to proceed.
 
 **The core chain:**
 
@@ -59,7 +59,7 @@ Actionable artifacts — structured enough for AI to design and build from
 
 Every capability traces back to a persona's pain point. Nothing gets built without a person behind it.
 
-At the decision step, the built-in ARB review runs a structured critique using ten reviewer personas — surfacing blind spots before the organization commits to a direction.
+At the decision step, the built-in ARB review runs a structured simulated critique using reviewer personas — surfacing blind spots before the organization commits to a direction. ARB output is not validation; it is decision support that must be weighed by a human alongside real evidence.
 
 ---
 
@@ -70,7 +70,7 @@ CLAUDE.md                          AI operating instructions for this framework
 how-to-start.md                    Plain-language guide for first-time users
 
 framework/
-  principles.md                    Nine principles that govern all work
+  principles.md                    Ten principles that govern all work
   workflow.md                      The 7-step EasyEA workflow
   capability-criteria.md           How to validate a capability — including AI-actionability
 
@@ -97,11 +97,12 @@ FRAMEWORK-IMPROVEMENTS.md          Gaps discovered through real work, tracked as
 2. Value at Every Step
 3. People-Centered by Design
 4. AI-Enabled from the Beginning
-5. Solve Real Problems
-6. Simplicity Over Completeness
-7. Lightweight and Built for Everyday Work
-8. Collaborative by Default
-9. Designed to Evolve
+5. Human in the Lead
+6. Solve Real Problems
+7. Simplicity Over Completeness
+8. Lightweight and Built for Everyday Work
+9. Collaborative by Default
+10. Designed to Evolve
 
 Full detail in `framework/principles.md`.
 

--- a/arb/how-arb-works.md
+++ b/arb/how-arb-works.md
@@ -1,8 +1,10 @@
 # How ARB Works
 
-The Architecture Review Board (ARB) is not a meeting. It is a structured critique step built into the EasyEA workflow. At Step 5 (Choose the Way Forward), you activate a set of ARB personas to challenge the options before a recommendation is made.
+The Architecture Review Board (ARB) is not a meeting. It is a structured simulated critique step built into the EasyEA workflow. At Step 5 (Choose the Way Forward), you activate a set of ARB personas to challenge the options before a recommendation is made.
 
-The goal is to surface blind spots, expose weak assumptions, and pressure-test decisions before the organization commits to them.
+The goal is to surface blind spots, expose weak assumptions, and pressure-test decisions before the organization commits to them. ARB output is decision support, not validation.
+
+Every ARB finding must be labeled **Simulated** unless it cites a real evidence source outside the persona critique.
 
 ---
 
@@ -42,7 +44,7 @@ In **Discovery Mode**, personas do not critique a proposal. They contribute guid
 | Long-term ownership before committing | Jake Lawson — who would own this in three years? |
 | Cost feasibility before scoping | Emily Johnson — is there a realistic budget for this? |
 
-Discovery Mode findings feed directly into `direction.md` and `personas.md`. They are not a review — they are a structured way to ask better questions at the start.
+Discovery Mode findings feed directly into `direction.md` and `personas.md`. They are not a review and they are not evidence — they are a structured way to ask better questions at the start.
 
 ---
 
@@ -106,6 +108,24 @@ For each persona, record:
 
 Incorporate findings into `options.md` before writing the recommendation.
 
+Keep findings small and decision-oriented. A useful ARB finding should fit in one short paragraph or table row and answer:
+
+- What decision does this affect?
+- What is the risk or opportunity?
+- What evidence level supports it?
+- What action is needed next?
+
+Use this evidence scale:
+
+| Evidence Level | Meaning |
+|----------------|---------|
+| None | The finding is a simulated concern only |
+| Assumption | Plausible, but not confirmed |
+| Human-confirmed | Confirmed by the human during the engagement |
+| Evidence-backed | Supported by a cited artifact, policy, research finding, data point, or observed behavior |
+
+Do not convert ARB confidence into implementation readiness. Readiness requires a human decision.
+
 ---
 
 ## Adapting ARB for Smaller or Less-Formal Organizations
@@ -138,6 +158,6 @@ These lightweight prompts can be used in addition to persona signature questions
 
 ## What Good ARB Output Looks Like
 
-A completed ARB review should produce clear findings for each activated persona — what they challenged, what was confirmed, and what needs to change. It is not a pass/fail gate. It is a structured way to make decisions with more confidence.
+A completed ARB review should produce clear findings for each activated persona — what they challenged, what was confirmed, and what needs to change. It is not a pass/fail gate, and it is not validation. It is a structured way to make decisions with more confidence.
 
 If a persona raises a challenge that cannot be answered, that is valuable information. It means the option is not ready for recommendation, or the recommendation needs to acknowledge the gap explicitly.

--- a/arb/personas.md
+++ b/arb/personas.md
@@ -1,8 +1,10 @@
 # ARB Personas
 
-Ten reviewer personas used during the EasyEA architecture review step. Each brings a distinct lens, set of signature questions, and review mode.
+Reviewer personas used during the EasyEA architecture review step. Each brings a distinct lens, set of signature questions, and review mode.
 
 Use these at Step 5 (Choose the Way Forward) to challenge options before a recommendation is made. See `arb/how-arb-works.md` for when to activate each persona and how.
+
+ARB persona output is simulated critique. It may expose useful risks and questions, but it is not validation and must not be presented as if real stakeholders reviewed or approved the work.
 
 > **Validated vs Provisional:** Personas marked ✅ have been used in at least one real engagement and their signature questions have been tested against actual work. Personas marked 🔲 are well-formed hypotheses — use them, but treat their questions as starting points and refine them after each use.
 
@@ -17,6 +19,7 @@ Use these at Step 5 (Choose the Way Forward) to challenge options before a recom
 | Dev Patel — Integration Architect | 🔲 Provisional |
 | Maya Patel — Data Privacy Architect | 🔲 Provisional |
 | Grace Holloway — Data & Analytics Architect | 🔲 Provisional |
+| Jordan Hayes — Architecture Governance Auditor | 🔲 Provisional |
 | Thomas Reed — Central IT Director | 🔲 Provisional |
 
 ---
@@ -240,6 +243,29 @@ Grace thinks about data in terms of decades, not sprints. She has seen organizat
 | Standard | Skeptical | Academic | Deep Dive | Risk Matrix |
 | Red Team | Combative | Academic | Nitpicky | Rapid-Fire Data Challenges |
 | Executive | Curious | Diplomatic | Strategic-Only | Executive Summary |
+| Governance | Skeptical | Academic | Nitpicky | Standards Checklist |
+
+---
+
+## Jordan Hayes — Architecture Governance Auditor
+
+Jordan is the person who asks whether a decision can survive contact with a real audit, a public-records request, or a governance review six months from now. He is not trying to turn lightweight architecture into bureaucracy. He is trying to make sure the organization can show its work when decisions matter.
+
+**Signature questions:**
+- Where is the evidence that this decision was validated?
+- What maturity level does this architecture actually represent — and how do we know?
+- If an auditor reviewed this tomorrow, what would they flag?
+
+**Satisfied when:** The proposal distinguishes evidence from assumption, labels simulated findings clearly, records who made the decision, and defines a lightweight proof trail that can be reviewed later.
+
+**Standard mode feedback sounds like:** "This may be a reasonable decision, but I cannot tell what evidence supports it. Which parts were confirmed by humans, which parts came from simulated review, and which assumptions are we accepting as risks?"
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Coaching | Curious | Academic | Curious | Guidance Questions |
+| Standard | Skeptical | Academic | Deep Dive | Risk Matrix |
+| Red Team | Combative | Direct | Nitpicky | Rapid-Fire Audit Challenges |
+| Executive | Neutral | Executive | Strategic-Only | Executive Summary |
 | Governance | Skeptical | Academic | Nitpicky | Standards Checklist |
 
 ---

--- a/framework/principles.md
+++ b/framework/principles.md
@@ -1,6 +1,6 @@
 # EasyEA Principles
 
-Nine principles that govern every EasyEA engagement. These are not guidelines — they are the criteria by which all work is evaluated.
+Ten principles that govern every EasyEA engagement. These are not guidelines — they are the criteria by which all work is evaluated.
 
 Apply these to every artifact, every decision, and every recommendation.
 
@@ -38,7 +38,15 @@ AI is not an add-on. It is built into how EasyEA works. Use AI to accelerate ins
 
 ---
 
-## 5. Solve Real Problems
+## 5. Human in the Lead
+
+AI may structure the work, draft artifacts, simulate review perspectives, and surface options. Humans make the decisions. No EasyEA engagement may move from discovery to recommendation, or from recommendation to implementation, without explicit human confirmation of the decision being made and the evidence supporting it.
+
+> **Test:** What decision is the human making right now? If the answer is unclear, stop and ask. If AI-generated or simulated material is influencing the decision, label it before proceeding.
+
+---
+
+## 6. Solve Real Problems
 
 Every method, artifact, and recommendation must address genuine organizational challenges — alignment gaps, delivery friction, legacy complexity, customer experience failures, siloed teams. No academic models, no theoretical constructs.
 
@@ -46,7 +54,7 @@ Every method, artifact, and recommendation must address genuine organizational c
 
 ---
 
-## 6. Simplicity Over Completeness
+## 7. Simplicity Over Completeness
 
 EasyEA prioritizes clarity, usability, and speed. If something cannot be explained quickly or used easily, simplify it or remove it. A clear, incomplete artifact is more useful than a comprehensive, unreadable one.
 
@@ -54,7 +62,7 @@ EasyEA prioritizes clarity, usability, and speed. If something cannot be explain
 
 ---
 
-## 7. Lightweight and Built for Everyday Work
+## 8. Lightweight and Built for Everyday Work
 
 The framework must fit naturally into business, product, and delivery workflows. Minimal artifacts. Lean governance. Just enough structure to support good decisions — nothing more.
 
@@ -62,7 +70,7 @@ The framework must fit naturally into business, product, and delivery workflows.
 
 ---
 
-## 8. Collaborative by Default
+## 9. Collaborative by Default
 
 Architecture is created with business, product, and technology teams — not delivered to them. The framework supports shared understanding, joint decision-making, and co-creation.
 
@@ -70,7 +78,7 @@ Architecture is created with business, product, and technology teams — not del
 
 ---
 
-## 9. Designed to Evolve
+## 10. Designed to Evolve
 
 EasyEA is a continuous, learning-focused framework. It supports experimentation, feedback loops, and incremental improvement. When real work reveals gaps, log them. When the framework is wrong, change it.
 

--- a/framework/workflow.md
+++ b/framework/workflow.md
@@ -2,6 +2,19 @@
 
 This is the backbone of every EasyEA engagement. Work moves through these steps in order. Not every engagement completes all seven — but you always know where you are and what comes next.
 
+EasyEA is human-led. AI may draft artifacts, simulate critique, and surface options, but humans confirm decisions and decide when evidence is strong enough to proceed.
+
+Use these evidence labels throughout the workflow:
+
+| Label | Use when... |
+|-------|-------------|
+| **Human-confirmed** | The human explicitly confirmed the statement during the engagement |
+| **Evidence-backed** | A real source supports the statement — user research, policy, data, artifact, observation, or decision record |
+| **Simulated** | The statement comes from an AI persona, ARB critique, or synthetic scenario |
+| **Assumption** | The statement is plausible but not yet confirmed |
+
+Simulated output is useful for probing design questions. It is not validation.
+
 ---
 
 ## Step 1 — Set the Direction
@@ -21,6 +34,8 @@ Align on what the organization is trying to achieve, what problems need solving,
 - What would success look like in 6–12 months?
 
 **Output:** `direction.md` and `compliance-register.md`
+
+**Decision gate:** The human confirms the goals, problems, constraints, and out-of-scope boundaries before personas or capabilities are allowed to drive downstream decisions.
 
 > **Compliance Register:** For government and regulated-sector engagements, start a Compliance Register at this step. Capture each mandatory requirement before design begins — source policy or law, what it mandates, how the product will address it, testing required, deadline, and status. This prevents compliance gaps from being discovered late in development. Update it whenever new requirements surface. See the Compliance Register template below.
 >
@@ -50,6 +65,8 @@ Learn what the people who use or are affected by this work actually need — whe
 
 > Every capability, design decision, and business rule must trace back to at least one persona's pain point or goal. Personas built here drive everything that follows.
 
+**Decision gate:** The human confirms which personas may drive the next step. Any persona still marked **Assumption** may be used to ask better questions, but not as the sole basis for implementation-ready capabilities.
+
 ---
 
 ## Step 3 — See How Work Really Happens
@@ -74,6 +91,8 @@ Create a clear picture of how the organization gets things done today. Understan
 
 **Output:** `current-state.md`
 
+**Decision gate:** The human confirms that the current-state description is accurate enough for opportunity analysis. Unverified process steps, data flows, or standards must remain labeled **Assumption** until confirmed.
+
 ---
 
 ## Step 4 — Find the Best Opportunities
@@ -92,6 +111,8 @@ Identify the improvements that would create the most value for the organization 
 - Where would small changes produce disproportionate value?
 
 **Output:** `opportunities.md`
+
+**Decision gate:** The human chooses which opportunities are worth option development. AI-ranked opportunities are recommendations, not decisions.
 
 > **Central Services Candidate Register (Portfolio EA):** For portfolio-level engagements — such as application or technology inventories across multiple agencies or divisions — identify technologies and capabilities that multiple teams use independently but could consolidate into a shared service. Capture each candidate with the teams involved, current duplication cost or risk, and the consolidation opportunity. This register is a standard output when EasyEA is applied to a portfolio intelligence use case.
 >
@@ -119,7 +140,11 @@ Compare a small set of options, weigh trade-offs and risks, and select the appro
 
 **Run ARB critique here.** See `arb/how-arb-works.md` for which personas to activate and how.
 
+ARB findings must be labeled **Simulated**. They can raise confidence, reveal risk, and shape questions, but they do not validate the decision.
+
 **Output:** `options.md`
+
+**Decision gate:** The human selects the way forward, defers the decision, or asks for more evidence. Do not treat a simulated ARB recommendation as approval.
 
 ---
 
@@ -141,6 +166,14 @@ Turn the decision into clear steps, responsibilities, funding alignment, and che
 
 **Output:** `coordination.md`
 
+**Implementation readiness gate:** Before implementation issues, PR-ready requirements, or coding work begin, confirm:
+
+- The human selected the option or explicitly approved the implementation direction
+- Remaining assumptions are resolved or accepted as named risks
+- Simulated ARB findings are labeled and translated into concrete actions or open questions
+- Capabilities trace to human-confirmed or evidence-backed persona needs
+- Ownership, testing, and success measures are clear enough to build against
+
 ---
 
 ## Step 7 — Track and Adjust
@@ -160,3 +193,5 @@ Monitor progress, look at what is working or not working, and adjust direction b
 - What should EasyEA do differently next time?
 
 **Output:** `success-metrics.md` and updates to `FRAMEWORK-IMPROVEMENTS.md`
+
+**Learning gate:** Update any assumptions that real outcomes disproved. If simulated findings were wrong or incomplete, capture the gap in `FRAMEWORK-IMPROVEMENTS.md` so the method improves.

--- a/how-to-start.md
+++ b/how-to-start.md
@@ -1,6 +1,6 @@
 # How to Start an EasyEA Engagement
 
-EasyEA works by giving Claude the framework as context, then letting Claude drive the work while you provide direction and judgment. This guide explains how to get started based on who you are and what you are working on.
+EasyEA works by giving Claude the framework as context, then letting Claude guide the work while you provide direction, judgment, and decisions. This guide explains how to get started based on who you are and what you are working on.
 
 ---
 
@@ -29,13 +29,13 @@ Start with one sentence describing the problem or opportunity. You do not need a
 **If you are a business owner:**
 > "I want to improve [area of the business or service]. I'm not sure exactly what needs to change — I need help figuring out who is affected and what we need to be able to do differently."
 
-Claude will start with Step 1 (Set the Direction) and move through the workflow from there.
+Claude will start with Step 1 (Set the Direction) and move through the workflow from there. At the end of each step, Claude should ask you to confirm whether the work is ready to proceed.
 
 ---
 
 ## What Claude Will Do
 
-Claude drives the engagement. You do not need to manage the process.
+Claude guides the engagement. You do not need to manage the process, but you do make the decisions.
 
 | What Claude does | What you do |
 |-----------------|------------|
@@ -43,8 +43,10 @@ Claude drives the engagement. You do not need to manage the process.
 | Drafts personas based on your context | Review and correct — you know your people better than Claude does |
 | Derives capabilities from persona pain points | Confirm the capabilities match what you actually need |
 | Validates each capability against the criteria | Flag anything that feels wrong or missing |
-| Runs ARB review at the decision step | Decide which findings need to be addressed before moving forward |
+| Runs simulated ARB review at the decision step | Decide which findings need to be addressed before moving forward |
 | Produces markdown artifacts at each step | Use them as input for the next phase of work |
+
+Claude may simulate users, reviewers, or scenarios to help you think. Treat those simulations as prompts for better questions, not as proof. If something is based on assumption or simulation, it should be labeled that way before it drives a decision.
 
 ---
 

--- a/projects/_template/capabilities.md
+++ b/projects/_template/capabilities.md
@@ -2,6 +2,7 @@
 
 **Version:** v1
 **Last Updated:** [Date]
+**Implementation Readiness:** Draft / Ready for issue definition / Ready for build
 
 This document describes what this product or service does — organized by the distinct capabilities it provides. Capabilities are derived from persona pain points and goals. Each capability traces back to at least one person this work must serve.
 
@@ -11,11 +12,11 @@ This document describes what this product or service does — organized by the d
 
 ## Capabilities Overview
 
-| ID | Capability | Primary | Secondary |
-|----|-----------|---------|-----------|
-| CAP-01 | [Capability Name] | [Persona who directly benefits] | [Persona who indirectly benefits] |
-| CAP-02 | [Capability Name] | [Primary persona] | [Secondary persona or —] |
-| CAP-03 | [Capability Name] | [Primary persona] | — |
+| ID | Capability | Primary | Secondary | Evidence Level |
+|----|-----------|---------|-----------|----------------|
+| CAP-01 | [Capability Name] | [Persona who directly benefits] | [Persona who indirectly benefits] | Human-confirmed / Evidence-backed / Assumption |
+| CAP-02 | [Capability Name] | [Primary persona] | [Secondary persona or —] | Human-confirmed / Evidence-backed / Assumption |
+| CAP-03 | [Capability Name] | [Primary persona] | — | Human-confirmed / Evidence-backed / Assumption |
 
 > **Primary** = the persona whose pain point this capability directly addresses. **Secondary** = a persona who benefits as a downstream effect. A capability must always have a primary. Secondary is optional.
 
@@ -29,6 +30,10 @@ This document describes what this product or service does — organized by the d
 
 *Serves: [Persona name] ([why — what pain point this addresses])*
 
+**Evidence:** [Human-confirmed / Evidence-backed / Assumption — source or validation need]
+**Success measure:** [How we will know this capability works]
+**Implementation notes:** [Open risks, dependencies, or assumptions that must be resolved before coding]
+
 ---
 
 ### CAP-02 — [Capability Name]
@@ -37,6 +42,10 @@ This document describes what this product or service does — organized by the d
 
 *Serves: [Persona name] ([pain point addressed])*
 
+**Evidence:** [Label and source]
+**Success measure:** [Measure]
+**Implementation notes:** [Notes]
+
 ---
 
 ### CAP-03 — [Capability Name]
@@ -44,6 +53,10 @@ This document describes what this product or service does — organized by the d
 [Description]
 
 *Serves: [Persona name] ([pain point addressed])*
+
+**Evidence:** [Label and source]
+**Success measure:** [Measure]
+**Implementation notes:** [Notes]
 
 ---
 
@@ -55,3 +68,19 @@ Every capability must have a row in this table. If a capability cannot be traced
 |---------|-----------|------------------------------|
 | [Persona name] | [Their specific pain point] | [CAP-XX — Capability Name] |
 | [Persona name] | [Pain point] | [CAP-XX — Capability Name] |
+
+---
+
+## Implementation Readiness Gate
+
+Before these capabilities become implementation issues or PR-ready requirements, confirm:
+
+- [ ] Each capability traces to a human-confirmed or evidence-backed persona need, or the human has explicitly accepted the assumption as a risk
+- [ ] Simulated ARB findings have been translated into actions, open questions, or accepted risks
+- [ ] Success measures are defined
+- [ ] Ownership and testing expectations are clear enough to build against
+- [ ] The next implementation issue is small, testable, and tied to one or more capability IDs
+
+**Gate decision:** Ready / Revise / Needs more evidence
+**Decision owner:** [Name or role]
+**Date:** [Date]

--- a/projects/_template/direction.md
+++ b/projects/_template/direction.md
@@ -3,6 +3,7 @@
 **Version:** v1
 **Last Updated:** [Date]
 **EasyEA Step:** 1 — Set the Direction
+**Decision Status:** Draft / Human-confirmed
 
 This document captures what the organization is trying to achieve, what problems need solving, and the constraints that shape the work. Everyone involved in this engagement should be able to read this and understand why the work exists.
 
@@ -57,6 +58,31 @@ In plain language, what would be true in 6–12 months if this engagement succee
 - [Success statement from the user/customer perspective]
 - [Success statement]
 - [Success statement]
+
+---
+
+## Evidence and Assumptions
+
+Track what is known, what is assumed, and what must be confirmed before moving forward.
+
+| Statement | Label | Source / Confirmation Needed |
+|-----------|-------|------------------------------|
+| [Goal, constraint, problem, or success statement] | Human-confirmed / Evidence-backed / Assumption | [Who confirmed it, source artifact, or what needs validation] |
+
+---
+
+## Human Decision Gate
+
+Before moving to Step 2, the human confirms:
+
+- [ ] Business goals are accurate enough to guide the engagement
+- [ ] Problems to solve are the right problems
+- [ ] Constraints and out-of-scope items are explicit
+- [ ] Any assumptions that may affect scope or risk are named
+
+**Gate decision:** Proceed / Revise / Pause
+**Decision owner:** [Name or role]
+**Date:** [Date]
 
 ---
 

--- a/projects/_template/personas.md
+++ b/projects/_template/personas.md
@@ -10,6 +10,8 @@ Every capability, design decision, and business rule must trace back to at least
 
 **System role:** [Submitter / Admin / Viewer / etc.]
 **Capabilities served:** [Fill in after capabilities.md is complete]
+**Evidence status:** Assumption / Human-confirmed / Evidence-backed / Validated with users
+**Evidence source:** [Human confirmation, interview, support ticket pattern, analytics, policy, observation, or "needs validation"]
 
 [2–3 sentences describing who this person is, what their job involves, and their relationship to the problem.]
 
@@ -25,12 +27,17 @@ Every capability, design decision, and business rule must trace back to at least
 
 > **Critical insight:** [The one thing about this persona that most affects whether the work succeeds or fails.]
 
+**Open assumptions**
+- [Assumption about this persona that must be confirmed before implementation]
+
 ---
 
 ## [Next Persona Name] — [One-Line Description]
 
 **System role:** [Role]
 **Capabilities served:** [Fill in after capabilities.md is complete]
+**Evidence status:** Assumption / Human-confirmed / Evidence-backed / Validated with users
+**Evidence source:** [Source or validation need]
 
 [Description]
 
@@ -43,6 +50,9 @@ Every capability, design decision, and business rule must trace back to at least
 - [Goal]
 
 > **Critical insight:** [The insight that shapes decisions for this persona.]
+
+**Open assumptions**
+- [Assumption]
 
 ---
 
@@ -61,3 +71,18 @@ Every capability, design decision, and business rule must trace back to at least
     ↓
 [Outcome for the organization or the people it serves]
 ```
+
+---
+
+## Human Decision Gate
+
+Before moving to Step 3 or using personas to drive implementation-ready capabilities, the human confirms:
+
+- [ ] Personas represent the right people affected by the work
+- [ ] Any assumed personas are marked and have a validation plan
+- [ ] Pain points and goals are specific enough to guide capability definition
+- [ ] No assumed persona is the sole basis for implementation without explicit human acceptance
+
+**Gate decision:** Proceed / Revise / Pause
+**Decision owner:** [Name or role]
+**Date:** [Date]


### PR DESCRIPTION
## Summary

Closes #37.

This PR tightens EasyEA around human-led AI-assisted development. It clarifies that AI can draft, structure, simulate, and critique, but humans make the decisions and decide when evidence is strong enough to proceed.

## Changes

- Adds `Human in the Lead` as a core EasyEA principle.
- Adds evidence labels for human-confirmed, evidence-backed, simulated, and assumption-based inputs.
- Adds workflow gates between direction, personas, current state, opportunities, options, coordination, and implementation readiness.
- Clarifies that ARB output is simulated critique, not validation.
- Adds Jordan Hayes as the missing governance/audit-readiness ARB persona referenced by the selection guide.
- Updates starter templates to capture evidence status, assumptions, and readiness decisions.
- Logs the methodology gap as FI-08 with a link to #37.

## Validation

- Ran `git diff --check` successfully.
- Reviewed changed docs for stale `AI drives` / `nine principles` wording and fixed the remaining occurrences.