### PR TITLE
[codex] Add SDLC personas for implementation readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,28 @@ For each persona you activate:
 
 ---
 
-### 5. Produce clean markdown artifacts
+### 5. Use SDLC personas before implementation
+
+After Step 6 (Coordinate the Work), and before opening implementation issues, drafting PR-ready requirements, or treating work as build-ready, run a lightweight simulated SDLC persona review when the work has meaningful delivery risk.
+
+SDLC personas do not decide what to build. They check whether the selected work is small enough, testable enough, deployable enough, supportable enough, and documented enough to move into implementation.
+
+Use `sdlc/how-sdlc-works.md` and `sdlc/personas.md`.
+
+Always include **Jordan Lee** (Delivery Lead) when shaping implementation issues. Every issue needs a clear slice, owner, and acceptance criteria.
+
+For each activated SDLC persona:
+- State their name and role
+- Apply their signature questions to the capability, issue, PR, or release plan
+- Surface only the highest-value delivery risks or missing details
+- Label each finding as simulated and assign an evidence level: none, assumption, human-confirmed, or evidence-backed
+- Translate findings into concrete issue, test, rollout, support, or documentation actions
+
+Do not use SDLC persona output as approval to build. The human still makes the readiness decision.
+
+---
+
+### 6. Produce clean markdown artifacts
 
 Every output is a markdown file. No slide decks, no prose summaries, no lists of bullet points handed back in chat. When a step is complete, produce a file.
 
@@ -133,7 +154,7 @@ Use the templates in `projects/_template/` as your starting point for any new en
 
 ---
 
-### 6. Principles that govern your work
+### 7. Principles that govern your work
 
 These are not suggestions. Apply them to everything you produce.
 
@@ -159,6 +180,7 @@ These are not suggestions. Apply them to everything you produce.
 - Do not skip the ARB review for significant decisions
 - Do not treat simulated ARB output, synthetic personas, or AI-generated assumptions as validation
 - Do not move from discovery to implementation without an explicit human readiness decision
+- Do not treat simulated SDLC persona output as delivery approval
 - Do not produce outputs in any format other than markdown
 - Do not treat any step as optional without noting the trade-off
 - Do not use EA jargon with users who are thinking in plain business language

--- a/FRAMEWORK-IMPROVEMENTS.md
+++ b/FRAMEWORK-IMPROVEMENTS.md
@@ -76,3 +76,12 @@ Each entry includes the context in which it was discovered, a recommended change
 **Discovered during:** GovEA instance-admin boundary analysis and follow-on EasyEA methodology review
 **Context:** EasyEA successfully structures AI-enabled development through personas, capabilities, issues, and PRs. However, the framework did not consistently distinguish human decisions, simulated critique, validated evidence, and implementation readiness. This creates a risk that AI-generated assumptions or simulated ARB findings quietly drive implementation as if they were validated facts.
 **Recommended change:** Make "Human in the Lead" an explicit principle and workflow directive. Add evidence labels for human-confirmed, evidence-backed, simulated, and assumption-based statements. Add decision gates between discovery, persona definition, opportunity selection, option recommendation, coordination, and implementation readiness. Require simulated outputs to stay small, decision-oriented, and tied to evidence levels.
+
+---
+
+### FI-09 — SDLC Personas for Implementation Readiness
+**Issue:** [#41](https://github.com/roballred/EasyEA/issues/41)
+**Status:** Drafted
+**Discovered during:** EasyEA methodology extension after adding human-led gates and MCP server support
+**Context:** EasyEA has strong ARB personas for architecture decision critique, but no equivalent delivery personas for the transition from capability definition into issues, PRs, release readiness, support, and learning. This leaves a gap between "we chose the right direction" and "this is ready to build and ship."
+**Recommended change:** Add SDLC personas and a lightweight SDLC review method. Use them after Step 6 and around issue shaping, PR readiness, release readiness, and learning review. Keep outputs simulated, concise, evidence-labeled, and tied to concrete delivery actions.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ framework/
   capability-criteria.md           How to validate a capability — including AI-actionability
 
 arb/
-  personas.md                      Ten ARB reviewer personas with modes
+  personas.md                      ARB reviewer personas with modes
   how-arb-works.md                 When and how to run an ARB review
+
+sdlc/
+  personas.md                      SDLC reviewer personas for issue, PR, release, and support readiness
+  how-sdlc-works.md                When and how to run SDLC persona review
 
 mcp/
   README.md                        MCP server for exposing EasyEA resources, prompts, and validation tools

--- a/framework/workflow.md
+++ b/framework/workflow.md
@@ -174,6 +174,10 @@ Turn the decision into clear steps, responsibilities, funding alignment, and che
 - Capabilities trace to human-confirmed or evidence-backed persona needs
 - Ownership, testing, and success measures are clear enough to build against
 
+**Run SDLC persona review here when implementation work is about to begin.** See `sdlc/how-sdlc-works.md` for which personas to activate and how.
+
+SDLC findings must be labeled **Simulated**. They can reveal issue-shaping, testing, deployment, support, documentation, or release risks, but they do not approve implementation.
+
 ---
 
 ## Step 7 — Track and Adjust

--- a/how-to-start.md
+++ b/how-to-start.md
@@ -44,9 +44,10 @@ Claude guides the engagement. You do not need to manage the process, but you do 
 | Derives capabilities from persona pain points | Confirm the capabilities match what you actually need |
 | Validates each capability against the criteria | Flag anything that feels wrong or missing |
 | Runs simulated ARB review at the decision step | Decide which findings need to be addressed before moving forward |
+| Runs simulated SDLC review before implementation | Decide whether the work is ready to become issues, PRs, releases, or support plans |
 | Produces markdown artifacts at each step | Use them as input for the next phase of work |
 
-Claude may simulate users, reviewers, or scenarios to help you think. Treat those simulations as prompts for better questions, not as proof. If something is based on assumption or simulation, it should be labeled that way before it drives a decision.
+Claude may simulate users, reviewers, delivery roles, or scenarios to help you think. Treat those simulations as prompts for better questions, not as proof. If something is based on assumption or simulation, it should be labeled that way before it drives a decision.
 
 ---
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -70,6 +70,8 @@ For this checkout, the command is:
 - `easyea://framework/capability-criteria`
 - `easyea://arb/how-it-works`
 - `easyea://arb/personas`
+- `easyea://sdlc/how-it-works`
+- `easyea://sdlc/personas`
 - `easyea://templates/direction`
 - `easyea://templates/personas`
 - `easyea://templates/capabilities`
@@ -84,6 +86,7 @@ For this checkout, the command is:
 - `derive-capabilities`
 - `run-arb-simulation`
 - `check-implementation-readiness`
+- `run-sdlc-review`
 
 ---
 
@@ -93,3 +96,4 @@ For this checkout, the command is:
 - `validate_capability`
 - `run_readiness_gate`
 - `recommend_arb_personas`
+- `recommend_sdlc_personas`

--- a/mcp/src/artifacts.ts
+++ b/mcp/src/artifacts.ts
@@ -64,6 +64,20 @@ export const artifacts: EasyEaArtifact[] = [
     path: "arb/personas.md"
   },
   {
+    id: "sdlc-how-it-works",
+    uri: "easyea://sdlc/how-it-works",
+    title: "How SDLC Personas Work",
+    description: "Guidance for simulated SDLC persona review in EasyEA.",
+    path: "sdlc/how-sdlc-works.md"
+  },
+  {
+    id: "sdlc-personas",
+    uri: "easyea://sdlc/personas",
+    title: "SDLC Personas",
+    description: "Delivery personas used for simulated implementation-readiness critique.",
+    path: "sdlc/personas.md"
+  },
+  {
     id: "template-direction",
     uri: "easyea://templates/direction",
     title: "Direction Template",

--- a/mcp/src/prompts.ts
+++ b/mcp/src/prompts.ts
@@ -155,4 +155,40 @@ export function registerPrompts(server: McpServer): void {
       ]
     })
   );
+
+  server.registerPrompt(
+    "run-sdlc-review",
+    {
+      title: "Run SDLC Persona Review",
+      description: "Run a concise, clearly labeled simulated SDLC review for issue, PR, release, or support readiness.",
+      argsSchema: {
+        reviewPoint: z
+          .enum(["Issue Shaping", "Build Planning", "PR Readiness", "Release Readiness", "Learning Review"])
+          .describe("The SDLC review point to run"),
+        work: z.string().describe("Capability, issue, PR, release plan, or delivery summary to review"),
+        focus: z.string().optional().describe("Specific concern, such as testing, deployment, support, security, or documentation")
+      }
+    },
+    ({ reviewPoint, work, focus }) => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: [
+              "Run an EasyEA SDLC persona review.",
+              "",
+              `Review point: ${reviewPoint}`,
+              `Focus: ${focus ?? "Select the most relevant SDLC personas"}`,
+              `Work to review:\n${work}`,
+              "",
+              "Use the SDLC persona guidance. Label all findings as Simulated unless tied to real evidence.",
+              "Keep findings small, delivery-oriented, and tied to evidence level and next action.",
+              "Do not treat the SDLC result as validation, approval, or permission to build."
+            ].join("\n")
+          }
+        }
+      ]
+    })
+  );
 }

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -220,4 +220,68 @@ export function registerTools(server: McpServer): void {
       });
     }
   );
+
+  server.registerTool(
+    "recommend_sdlc_personas",
+    {
+      title: "Recommend SDLC Personas",
+      description: "Recommend simulated SDLC personas based on review point and delivery focus.",
+      inputSchema: {
+        reviewPoint: z.enum(["Issue Shaping", "Build Planning", "PR Readiness", "Release Readiness", "Learning Review"]),
+        workSize: z.enum(["small", "standard", "significant"]),
+        focusAreas: z
+          .array(z.string())
+          .optional()
+          .describe("Focus areas such as frontend, backend, testing, deployment, support, documentation, security, data, or capacity")
+      },
+      annotations: {
+        readOnlyHint: true,
+        idempotentHint: true
+      }
+    },
+    async ({ reviewPoint, workSize, focusAreas = [] }) => {
+      const normalized = focusAreas.map((area) => area.toLowerCase());
+      const recommendations = new Set<string>();
+
+      if (reviewPoint === "Issue Shaping") {
+        recommendations.add("Jordan Lee — Delivery Lead");
+      }
+
+      const addIf = (terms: string[], persona: string) => {
+        if (normalized.some((area) => terms.some((term) => area.includes(term)))) {
+          recommendations.add(persona);
+        }
+      };
+
+      addIf(["scope", "issue", "acceptance", "slice"], "Jordan Lee — Delivery Lead");
+      addIf(["frontend", "ui", "accessibility", "responsive", "state"], "Priya Shah — Frontend Engineer");
+      addIf(["backend", "api", "service", "domain", "logic"], "Marco Alvarez — Backend Engineer");
+      addIf(["test", "qa", "regression", "acceptance"], "Nina Patel — QA Engineer");
+      addIf(["deploy", "release", "rollback", "monitor", "observability", "config"], "Sam Rivera — DevOps Engineer");
+      addIf(["security", "authorization", "secret", "input"], "Omar Brooks — Application Security Engineer");
+      addIf(["data", "migration", "report", "quality"], "Grace Lin — Data Engineer");
+      addIf(["support", "runbook", "incident", "help"], "Taylor Morgan — Support Analyst");
+      addIf(["docs", "documentation", "training", "release notes"], "Casey Nguyen — Documentation and Training Lead");
+      addIf(["capacity", "dependency", "sequence", "team"], "Morgan Ellis — Engineering Manager");
+
+      if (recommendations.size === 0) {
+        recommendations.add("Jordan Lee — Delivery Lead");
+        recommendations.add("Nina Patel — QA Engineer");
+      }
+
+      const limits = {
+        small: 2,
+        standard: 5,
+        significant: 10
+      } as const;
+
+      return asText({
+        reviewPoint,
+        workSize,
+        recommendedCount: limits[workSize],
+        personas: Array.from(recommendations).slice(0, limits[workSize]),
+        note: "SDLC persona output is simulated critique, not validation or delivery approval."
+      });
+    }
+  );
 }

--- a/sdlc/how-sdlc-works.md
+++ b/sdlc/how-sdlc-works.md
@@ -1,0 +1,120 @@
+# How SDLC Personas Work
+
+SDLC personas are simulated delivery reviewers used after EasyEA has selected a direction and is preparing to turn capabilities into implementation issues, PRs, releases, and operational support.
+
+ARB personas help decide whether a direction is sound. SDLC personas help decide whether the work is ready to build, test, ship, operate, and learn from.
+
+SDLC persona output is simulated critique. It may expose useful gaps and questions, but it is not validation and must not be presented as if real delivery team members reviewed or approved the work.
+
+---
+
+## When to Use SDLC Personas
+
+Use SDLC personas after **Step 6 — Coordinate the Work**, when the human has selected the implementation direction and the team is preparing implementation issues or PR-ready requirements.
+
+Use them again when a PR, release, or production change needs a lightweight delivery-readiness check.
+
+Do not use SDLC personas to override human decisions. Use them to make delivery risks visible before implementation moves forward.
+
+---
+
+## SDLC Review Points
+
+| Review Point | Use When... | Output |
+|--------------|-------------|--------|
+| Issue Shaping | A capability is becoming one or more implementation issues | Issue slices, acceptance criteria gaps, dependencies |
+| Build Planning | The team is deciding how to implement the work | technical risks, sequencing, ownership gaps |
+| PR Readiness | A pull request is ready for human review | review focus, missing tests, documentation gaps |
+| Release Readiness | A change is about to ship | rollout, rollback, monitoring, support readiness |
+| Learning Review | The work shipped or failed to ship cleanly | lessons learned and framework improvements |
+
+---
+
+## How Many Personas to Activate
+
+| Work Size | Personas to Activate |
+|-----------|---------------------|
+| Small, low-risk issue | 1–2 |
+| Standard feature or workflow change | 3–5 |
+| Significant release, data migration, security-sensitive change, or cross-team dependency | 6–10 |
+
+Always include **Jordan Lee** (Delivery Lead) when shaping issues. Every implementation effort needs a clear slice, owner, and acceptance criteria.
+
+---
+
+## Select the Relevant Personas
+
+| If the work involves... | Activate... |
+|-------------------------|-------------|
+| issue slicing, scope control, acceptance criteria | Jordan Lee |
+| user interface, accessibility, frontend behavior | Priya Shah |
+| APIs, services, data model, domain logic | Marco Alvarez |
+| tests, regression risk, acceptance coverage | Nina Patel |
+| deployment, environments, rollback, observability | Sam Rivera |
+| implementation security, secrets, authorization | Omar Brooks |
+| data migration, reporting, data quality | Grace Lin |
+| support model, help desk, runbooks, incident handoff | Taylor Morgan |
+| documentation, training, release notes | Casey Nguyen |
+| delivery sequencing, dependencies, team capacity | Morgan Ellis |
+
+Some lenses overlap with ARB personas. Use ARB personas for architecture direction and governance. Use SDLC personas for implementation readiness and delivery execution.
+
+---
+
+## How to Run an SDLC Persona Review
+
+### 1. Name the review point
+
+State whether this is Issue Shaping, Build Planning, PR Readiness, Release Readiness, or Learning Review.
+
+### 2. Select personas
+
+Choose the smallest set of personas needed for the risk at hand. More personas are not better if they create noise.
+
+### 3. Apply signature questions
+
+For each activated persona, apply their signature questions to the capability, issue, PR, or release plan.
+
+### 4. Capture concise findings
+
+For each persona, record:
+
+- What they challenged
+- What delivery risk or gap was surfaced
+- What is ready enough to proceed
+- What action is needed before the next gate
+
+Keep SDLC findings small and action-oriented. A useful finding should fit in one short paragraph or table row and answer:
+
+- What implementation decision does this affect?
+- What risk does it expose?
+- What evidence level supports it?
+- What action is needed next?
+
+Use the same evidence labels as the core EasyEA workflow:
+
+| Evidence Level | Meaning |
+|----------------|---------|
+| None | The finding is a simulated concern only |
+| Assumption | Plausible, but not confirmed |
+| Human-confirmed | Confirmed by the human during the engagement |
+| Evidence-backed | Supported by a cited artifact, test result, policy, user research, production observation, or delivery data |
+
+---
+
+## What Good SDLC Output Looks Like
+
+Good SDLC output helps a human decide whether the work is ready for the next delivery step.
+
+It should produce concrete next actions, such as:
+
+- split the issue smaller
+- add missing acceptance criteria
+- add or change tests
+- clarify ownership
+- define rollback
+- add monitoring
+- update documentation
+- mark an assumption as accepted risk
+
+It should not produce broad commentary, generic best practices, or simulated approval.

--- a/sdlc/personas.md
+++ b/sdlc/personas.md
@@ -1,0 +1,264 @@
+# SDLC Personas
+
+SDLC personas are simulated delivery reviewers used when EasyEA work moves from capability definition into implementation issues, PRs, release planning, and operational support.
+
+Use these after Step 6 (Coordinate the Work) and during implementation readiness checks. See `sdlc/how-sdlc-works.md` for when to activate each persona and how.
+
+SDLC persona output is simulated critique. It may expose delivery risks and missing work, but it is not validation and must not be presented as if real delivery team members reviewed or approved the work.
+
+> **Validated vs Provisional:** Personas marked ✅ have been used in at least one real engagement and their signature questions have been tested against actual work. Personas marked 🔲 are well-formed hypotheses — use them, but treat their questions as starting points and refine them after each use.
+
+| Persona | Status |
+|---------|--------|
+| Jordan Lee — Delivery Lead | 🔲 Provisional |
+| Priya Shah — Frontend Engineer | 🔲 Provisional |
+| Marco Alvarez — Backend Engineer | 🔲 Provisional |
+| Nina Patel — QA Engineer | 🔲 Provisional |
+| Sam Rivera — DevOps Engineer | 🔲 Provisional |
+| Omar Brooks — Application Security Engineer | 🔲 Provisional |
+| Grace Lin — Data Engineer | 🔲 Provisional |
+| Taylor Morgan — Support Analyst | 🔲 Provisional |
+| Casey Nguyen — Documentation and Training Lead | 🔲 Provisional |
+| Morgan Ellis — Engineering Manager | 🔲 Provisional |
+
+---
+
+## Review Modes
+
+| Mode | When to Use |
+|------|-------------|
+| **Issue Shaping** | A capability is becoming implementation issues |
+| **Build Planning** | The team is deciding how to implement the work |
+| **PR Readiness** | A PR is ready for human review |
+| **Release Readiness** | A change is about to ship |
+| **Learning Review** | The team is capturing what worked, failed, or changed |
+
+---
+
+## Jordan Lee — Delivery Lead
+
+Jordan cares about making work small enough to finish and clear enough to review. He has seen strong product ideas fail because they entered delivery as giant, ambiguous issues with no owner and no definition of done.
+
+**Signature questions:**
+- What is the smallest useful slice?
+- What acceptance criteria prove this is done?
+- Who owns the next decision if scope changes?
+
+**Satisfied when:** The work is split into small, testable issues with clear acceptance criteria, owners, dependencies, and a visible decision path for scope changes.
+
+**Standard mode feedback sounds like:** "This capability is real, but it is not yet an issue. I need the first slice, the acceptance criteria, and the owner before implementation starts."
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Focused | Direct | Deep Dive | Scope Slicing |
+| Build Planning | Neutral | Diplomatic | Deep Dive | Dependency Check |
+| PR Readiness | Curious | Direct | Light Deep Dive | Acceptance Review |
+| Release Readiness | Skeptical | Direct | Strategic-Only | Go/No-Go Risks |
+| Learning Review | Curious | Diplomatic | Curious | Lessons Learned |
+
+---
+
+## Priya Shah — Frontend Engineer
+
+Priya looks for the point where a clear capability becomes a confusing user experience. She cares about accessible, responsive, understandable interfaces that behave predictably under real user conditions.
+
+**Signature questions:**
+- What exact user interaction must work?
+- What accessibility or responsive behavior is required?
+- What empty, loading, error, and permission states are missing?
+
+**Satisfied when:** The issue names the user interaction, states, accessibility expectations, and visual behavior clearly enough that implementation and review are not guesswork.
+
+**Standard mode feedback sounds like:** "I can build the happy path from this, but I do not know what happens when the user lacks permission, the data is empty, or the request fails."
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Curious | Direct | Deep Dive | UI State Checklist |
+| Build Planning | Focused | Direct | Deep Dive | Interaction Review |
+| PR Readiness | Skeptical | Direct | Nitpicky | State and A11y Review |
+| Release Readiness | Neutral | Diplomatic | Light Deep Dive | UX Risk Summary |
+| Learning Review | Curious | Empathetic | Curious | User Friction Notes |
+
+---
+
+## Marco Alvarez — Backend Engineer
+
+Marco looks for unclear domain logic, hidden data model changes, and API contracts that are easy to describe but hard to maintain. He is pragmatic and wants the issue to reveal its invariants before code starts.
+
+**Signature questions:**
+- What data or state changes when this runs?
+- What rules must always be true?
+- What contract does another part of the system depend on?
+
+**Satisfied when:** The issue identifies data changes, business invariants, API or service contracts, error cases, and migration implications.
+
+**Standard mode feedback sounds like:** "The capability is clear, but the domain rule is not. What exactly becomes true after this action, and what must never be allowed?"
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Focused | Direct | Deep Dive | Domain Questions |
+| Build Planning | Neutral | Direct | Deep Dive | Contract Review |
+| PR Readiness | Skeptical | Direct | Nitpicky | Logic and Edge Cases |
+| Release Readiness | Neutral | Diplomatic | Light Deep Dive | Compatibility Risks |
+| Learning Review | Curious | Diplomatic | Curious | Design Debt Notes |
+
+---
+
+## Nina Patel — QA Engineer
+
+Nina is the person who asks how the team will know the work actually works. She focuses on test coverage, regression risk, acceptance criteria, and the uncomfortable edge cases that users find five minutes after release.
+
+**Signature questions:**
+- What tests prove the acceptance criteria?
+- What regression risk does this create?
+- What edge case would make this look done but fail in practice?
+
+**Satisfied when:** Acceptance criteria map to testable behavior, regression areas are named, and the issue or PR includes a realistic test plan.
+
+**Standard mode feedback sounds like:** "I see what we intend to build. I do not yet see how we prove it works or what existing behavior could break."
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Curious | Direct | Deep Dive | Testability Review |
+| Build Planning | Neutral | Direct | Deep Dive | Regression Map |
+| PR Readiness | Skeptical | Direct | Nitpicky | Test Gap Review |
+| Release Readiness | Skeptical | Diplomatic | Deep Dive | Risk-Based Test Summary |
+| Learning Review | Curious | Diplomatic | Curious | Defect Pattern Notes |
+
+---
+
+## Sam Rivera — DevOps Engineer
+
+Sam thinks about environments, configuration, observability, and rollback before anyone celebrates a merge. He wants changes to be deployable without heroics and recoverable when reality gets involved.
+
+**Signature questions:**
+- How is this deployed and configured?
+- What will tell us it is working or failing?
+- What is the rollback or recovery path?
+
+**Satisfied when:** Deployment steps, environment/configuration changes, monitoring signals, alerts, and rollback expectations are explicit.
+
+**Standard mode feedback sounds like:** "This is mergeable, but I do not know how we will deploy it, observe it, or back it out if it behaves badly."
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Neutral | Direct | Curious | Deployment Questions |
+| Build Planning | Focused | Direct | Deep Dive | Release Path Review |
+| PR Readiness | Skeptical | Direct | Deep Dive | Config and Observability Review |
+| Release Readiness | Skeptical | Direct | Nitpicky | Rollout Checklist |
+| Learning Review | Curious | Diplomatic | Curious | Operational Lessons |
+
+---
+
+## Omar Brooks — Application Security Engineer
+
+Omar focuses on the implementation details that turn a sound architecture into a secure or insecure product. He looks for authorization gaps, secret handling, input validation, dependency risk, and logging mistakes.
+
+**Signature questions:**
+- What authorization rule is enforced in code?
+- Are secrets, tokens, or sensitive data exposed anywhere?
+- What untrusted input must be validated?
+
+**Satisfied when:** The issue or PR names authorization rules, sensitive data handling, validation expectations, dependency risks, and security-relevant tests.
+
+**Standard mode feedback sounds like:** "The architecture says access is controlled, but where is that enforced in this implementation, and what test proves it?"
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Curious | Direct | Deep Dive | Security Requirements |
+| Build Planning | Skeptical | Direct | Deep Dive | Threat Questions |
+| PR Readiness | Skeptical | Direct | Nitpicky | Security Review |
+| Release Readiness | Skeptical | Direct | Nitpicky | Exposure Check |
+| Learning Review | Curious | Diplomatic | Curious | Security Lessons |
+
+---
+
+## Grace Lin — Data Engineer
+
+Grace looks for data changes that seem small until they affect reporting, migration, quality, or downstream consumers. She wants data shape, ownership, and quality checks defined before implementation starts.
+
+**Signature questions:**
+- What data is created, changed, migrated, or deleted?
+- What quality rule prevents bad data from spreading?
+- Who or what consumes this data downstream?
+
+**Satisfied when:** Data model changes, migration needs, validation rules, downstream consumers, and backfill or cleanup expectations are explicit.
+
+**Standard mode feedback sounds like:** "This field looks simple, but it changes the meaning of the record. What happens to existing data and downstream reports?"
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Curious | Academic | Deep Dive | Data Shape Questions |
+| Build Planning | Neutral | Academic | Deep Dive | Migration Review |
+| PR Readiness | Skeptical | Academic | Nitpicky | Data Quality Review |
+| Release Readiness | Skeptical | Direct | Deep Dive | Backfill and Consumer Check |
+| Learning Review | Curious | Diplomatic | Curious | Data Lessons |
+
+---
+
+## Taylor Morgan — Support Analyst
+
+Taylor thinks about the first person who gets called when the change confuses a user or fails in production. She looks for support paths, runbooks, known issues, and signals that help humans diagnose problems.
+
+**Signature questions:**
+- How will support know what happened?
+- What should a user or support person do when this fails?
+- What known issue or help content needs to exist?
+
+**Satisfied when:** Support paths, user-facing failure behavior, diagnostic signals, runbooks, and escalation paths are clear.
+
+**Standard mode feedback sounds like:** "When this fails, someone is going to ask support what happened. Right now support has no answer and no place to look."
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Curious | Empathetic | Curious | Support Scenario Questions |
+| Build Planning | Neutral | Diplomatic | Light Deep Dive | Handoff Review |
+| PR Readiness | Curious | Direct | Light Deep Dive | Supportability Check |
+| Release Readiness | Skeptical | Direct | Deep Dive | Runbook Review |
+| Learning Review | Curious | Empathetic | Curious | Support Pattern Notes |
+
+---
+
+## Casey Nguyen — Documentation and Training Lead
+
+Casey watches for the gap between what the product does and what people understand. He cares about release notes, help content, onboarding, and plain-language explanations for non-technical users.
+
+**Signature questions:**
+- What does the user need to know when this changes?
+- What documentation or training must be updated?
+- Is the explanation plain enough for the people affected?
+
+**Satisfied when:** User-facing changes are explained in plain language, documentation needs are identified, and release notes or training updates are included where needed.
+
+**Standard mode feedback sounds like:** "The change may be correct, but nobody has explained it to the people whose work just changed."
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Curious | Diplomatic | Curious | Documentation Needs |
+| Build Planning | Neutral | Diplomatic | Light Deep Dive | Communication Plan |
+| PR Readiness | Curious | Direct | Light Deep Dive | Docs Gap Review |
+| Release Readiness | Focused | Diplomatic | Deep Dive | Release Notes Review |
+| Learning Review | Curious | Empathetic | Curious | Training Feedback |
+
+---
+
+## Morgan Ellis — Engineering Manager
+
+Morgan looks at the work through the lens of team capacity, sequencing, dependencies, and sustainability. She wants a delivery plan that can survive real calendars, interruptions, and competing priorities.
+
+**Signature questions:**
+- What dependency or capacity risk could block this?
+- Is the sequence realistic for the team doing the work?
+- What trade-off are we making explicit?
+
+**Satisfied when:** The plan names dependencies, sequencing risks, ownership, staffing or capacity constraints, and the trade-offs accepted by the human decision-maker.
+
+**Standard mode feedback sounds like:** "This is technically reasonable, but the sequence assumes capacity the team may not have. Which trade-off are we choosing?"
+
+| Mode | Mood | Tone | Energy | Feedback Style |
+|------|------|------|--------|---------------|
+| Issue Shaping | Focused | Diplomatic | Deep Dive | Capacity and Scope Review |
+| Build Planning | Skeptical | Direct | Deep Dive | Delivery Risk Review |
+| PR Readiness | Neutral | Diplomatic | Light Deep Dive | Review Load Check |
+| Release Readiness | Skeptical | Diplomatic | Deep Dive | Dependency Summary |
+| Learning Review | Curious | Diplomatic | Curious | Team Sustainability Notes |


### PR DESCRIPTION
## Summary

Closes #41.

Adds SDLC personas as the delivery-side companion to ARB personas. ARB personas help pressure-test architecture direction; SDLC personas help pressure-test whether selected work is ready to become issues, PRs, releases, support plans, and learning loops.

## Changes

- Adds `sdlc/personas.md` with 10 provisional delivery personas:
  - Delivery Lead
  - Frontend Engineer
  - Backend Engineer
  - QA Engineer
  - DevOps Engineer
  - Application Security Engineer
  - Data Engineer
  - Support Analyst
  - Documentation and Training Lead
  - Engineering Manager
- Adds `sdlc/how-sdlc-works.md` with review points for issue shaping, build planning, PR readiness, release readiness, and learning review.
- Wires SDLC review into Step 6 implementation readiness guidance.
- Updates `CLAUDE.md` so agents use SDLC personas before implementation when delivery risk warrants it.
- Updates `how-to-start.md`, `README.md`, and `FRAMEWORK-IMPROVEMENTS.md`.
- Exposes SDLC docs through the MCP server and adds:
  - `run-sdlc-review` prompt
  - `recommend_sdlc_personas` tool

## Validation

- Ran `npm run build` in `mcp/` successfully.
- Smoke-tested the MCP server over stdio:
  - listed 13 resources
  - confirmed `easyea://sdlc/personas` is available
  - confirmed `run-sdlc-review` prompt is available
  - confirmed `recommend_sdlc_personas` tool is available
  - read SDLC personas resource
  - called `recommend_sdlc_personas` successfully
- Ran `git diff --check` successfully.